### PR TITLE
bugfix in meetup creation

### DIFF
--- a/community/meetups/models.py
+++ b/community/meetups/models.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import User
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils import timezone
+from django.conf import settings
 from datetime import datetime, timedelta
 from . import tasks
 
@@ -25,7 +26,7 @@ class Meetup(models.Model):
             create_task = True
         super(Meetup, self).save(*args, **kwargs)
         if create_task:
-            end_time = self.created_date + timedelta(hours=self.duration)
+            end_time = self.endtime()
             try:
                 tasks.set_inactive_after_time.apply_async((self.community.id, self.id), eta=end_time)
             except:
@@ -79,7 +80,7 @@ class Attendee(models.Model):
 @receiver(post_save, sender=Meetup)
 def create_meetup_creator_attendee(sender, instance, created, **kwargs):
     if created:
-        attendee = Attendee.objects.create(meetup=instance, user=instance.creator, signup_time=datetime.now(), updated=datetime.now())
+        attendee = Attendee.objects.create(meetup=instance, user=instance.creator, signup_time=timezone.now(), updated=timezone.now())
         attendee.save()
 
 

--- a/community/meetups/views.py
+++ b/community/meetups/views.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import User
 from .models import Meetup, Attendee
 from community.communities.models import Community
 from .forms import CreateMeetupForm, AttendMeetupForm
+from django.utils import timezone
 import datetime
 
 
@@ -67,7 +68,7 @@ def meetups_create(request, slug):
     form = CreateMeetupForm
     user = request.user
     if request.method == 'POST':
-        meetup = Meetup(community=community, creator=user, created_date=datetime.datetime.now())
+        meetup = Meetup(community=community, creator=user, created_date=timezone.now())
         form = CreateMeetupForm(request.POST, request.FILES, instance=meetup)
         form.save()
         return redirect('meetups_view', slug=slug, id=meetup.id)


### PR DESCRIPTION
meetups creation form was using tz unaware object for getting current time.  Fixed so that meetups are no longer auto-deactivated on creation.